### PR TITLE
Support for string values without quotes.

### DIFF
--- a/lib/tf/hcl/parser.rb
+++ b/lib/tf/hcl/parser.rb
@@ -48,6 +48,7 @@ module Tf
         clause('OCTAL') { |i| Tf::Hcl::Octal.new(i) }
         clause('SCIENTIFIC_NOTATION') { |i| Tf::Hcl::BigDecimal.new(i) }
         clause('STRING') { |i| Tf::Hcl::String.new(i) }
+        clause('IDENT') { |i| Tf::Hcl::String.new(i) }
         clause('MULTILINE_STRING') { |i| Tf::Hcl::MultiLineString.new(*i) }
         clause('list') { |i| Tf::Hcl::List.new(i) }
         clause('object') { |i| Tf::Hcl::Object.new(i) }


### PR DESCRIPTION
Parsing definitions like (notice `type` attribute value):
```
variable "scale_web" {
  type    = string
  default = "2"
}
```